### PR TITLE
Log to stdout not syslog

### DIFF
--- a/lora_pkt_fwd/inc/trace.h
+++ b/lora_pkt_fwd/inc/trace.h
@@ -26,7 +26,7 @@ Maintainer: Michael Coracin
 #define DEBUG_BEACON    0
 #define DEBUG_LOG       1
 
-#define MSG(args...) syslog(LOG_INFO, args) /* message that is destined to the user */
+#define MSG(args...) printf(args) /* message that is destined to the user */
 #define MSG_DEBUG(FLAG, fmt, ...)                                                                         \
             do  {                                                                                         \
                 if (FLAG)                                                                                 \


### PR DESCRIPTION
@JayKickliter This change short circuits logging to `/var/data/log/messages`. I still see LoRaWAN packets in `/var/log/miner/console.log`.